### PR TITLE
Add Python trigger execution utilities

### DIFF
--- a/plt/generatePythonTriggerCode.inc.php
+++ b/plt/generatePythonTriggerCode.inc.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Generates Python code for sandbox execution based on provided trigger code and row data.
+ *
+ * @param string $functionName The name of the Python function to generate.
+ * @param string $pyCode       The Python code to embed within the generated function.
+ * @param array  $row          The row data to pass to the generated function.
+ *
+ * @return string The complete Python code ready for sandbox execution.
+ */
+function generatePythonTriggerCode($functionName, $pyCode, $row) {
+    // Build constant definitions
+    $constants = '';
+    foreach (sql("SELECT Name, Type, Value FROM SYS_PRD_BND.Constants") as $const) {
+        switch ($const['Type']) {
+            case 'String':
+                $val = "'" . str_replace("'", "\\'", $const['Value']) . "'";
+                break;
+            case 'Json':
+                $val = 'json.loads(' . json_encode($const['Value']) . ')';
+                break;
+            default: // Int or Double
+                $val = $const['Value'];
+        }
+        $constants .= "{$const['Name']} = {$val}\n";
+    }
+
+    // Prepare imports
+    $imports = "import json\n" . getPythonImports();
+
+    // Prepare row data for Python
+    $rowJson = str_replace("'", "\\'", json_encode($row));
+
+    // Indent user-provided Python code
+    $indentedCode = implode("\n", array_map(fn($line) => '    ' . $line, explode("\n", $pyCode)));
+
+    // Assemble complete Python script
+    $pythonCode = <<<PY
+$imports
+$constants
+def $functionName(data, error):
+$indentedCode
+
+data = json.loads('$rowJson')
+error = None
+$functionName(data, error)
+print(json.dumps(data))
+PY;
+
+    return $pythonCode;
+}

--- a/plt/runSandboxedPython.inc.php
+++ b/plt/runSandboxedPython.inc.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Runs dynamically generated Python code in a sandboxed environment.
+ *
+ * @param string $code   The Python code to execute.
+ * @param string &$stdout Captured standard output from the execution.
+ * @param string &$stderr Captured standard error from the execution.
+ *
+ * @return int Exit code of the executed Python script (0 means success).
+ */
+function runSandboxedPython($code, &$stdout = null, &$stderr = null) {
+    // Create a temporary file to hold the Python code
+    $tempFile = tempnam(sys_get_temp_dir(), 'sandboxed_') . '.py';
+
+    // Write the generated Python code to the temporary file
+    file_put_contents($tempFile, $code);
+
+    // Prepare the command for executing the Python code
+    $command = "/usr/bin/python3 " . escapeshellarg($tempFile);
+
+    // Descriptor spec to capture stdout and stderr
+    $descriptorspec = [
+        1 => ['pipe', 'w'], // stdout
+        2 => ['pipe', 'w'], // stderr
+    ];
+
+    // Execute the Python code using proc_open
+    $process = proc_open($command, $descriptorspec, $pipes);
+
+    if (!is_resource($process)) {
+        unlink($tempFile);
+        throw new Exception('Failed to execute sandboxed Python code.');
+    }
+
+    // Capture stdout and stderr
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+
+    // Get the exit code
+    $exitCode = proc_close($process);
+
+    // Cleanup temporary file
+    unlink($tempFile);
+
+    return $exitCode;
+}


### PR DESCRIPTION
## Summary
- add runSandboxedPython() for executing generated Python code
- add generatePythonTriggerCode() to build Python scripts with constants, imports and JSON handling

## Testing
- `php -l plt/runSandboxedPython.inc.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6844179dcc908321898b10d1d9ab7847