### PR TITLE
Add Node.js support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ test_code.php
 modules/
 
 requirements.txt
+package.json
+package-lock.json
+npm.sync
+node_modules/

--- a/DbContinuousIntegrationWrapper.sh
+++ b/DbContinuousIntegrationWrapper.sh
@@ -2,10 +2,12 @@
 cd "$(dirname ${BASH_SOURCE[0]})"
 while [[ 1 ]]
 do
-	killall DbContinuousIntegrationWrapper.sh
-	/usr/bin/php composer.json.php > composer.json
-	touch -t $(/usr/bin/mysql -se "SELECT DATE_FORMAT(LastUpdated, '%Y%m%d%H%i.%s') FROM SYS_PRD_BND.Composer ORDER BY LastUpdated DESC LIMIT 1") composer.json
-	make
-	/usr/bin/php DbContinuousIntegration.php
-	sleep 10
+        killall DbContinuousIntegrationWrapper.sh
+        /usr/bin/php composer.json.php > composer.json
+        touch -t $(/usr/bin/mysql -se "SELECT DATE_FORMAT(LastUpdated, '%Y%m%d%H%i.%s') FROM SYS_PRD_BND.Composer ORDER BY LastUpdated DESC LIMIT 1") composer.json
+        /usr/bin/php package.json.php > package.json
+        touch -t $(/usr/bin/mysql -se "SELECT DATE_FORMAT(LastUpdated, '%Y%m%d%H%i.%s') FROM SYS_PRD_BND.Npm ORDER BY LastUpdated DESC LIMIT 1") package.json
+        make
+        /usr/bin/php DbContinuousIntegration.php
+        sleep 10
 done

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+all: composer.sync requirements.sync npm.sync
+
 composer.sync: composer.json
 	COMPOSER_ALLOW_SUPERUSER=1 composer update > $@ 2>&1
 
 requirements.sync: requirements.txt
-	pip install -r requirements.txt $@
+	pip install -r requirements.txt > $@ 2>&1
+
+npm.sync: package.json
+	npm install > $@ 2>&1
+
 install:
-	echo "Add this line to crontab -e"
-	echo '@reboot /bin/bash /root/DbContinuousIntegration/DbContinuousIntegrationWrapper.sh 2> /dev/null > /dev/null &'
-	echo 
-	echo 'CREATE TABLE SYS_PRD_BND.Tables (Name, onUpdate_phpCode, onUpdate_pyCode, LastUpdated);' | sudo mysql
+@echo "Add this line to crontab -e"
+@echo '@reboot /bin/bash /root/DbContinuousIntegration/DbContinuousIntegrationWrapper.sh 2> /dev/null > /dev/null &'
+@echo
+@echo 'CREATE TABLE SYS_PRD_BND.Tables (Name, onUpdate_phpCode, onUpdate_pyCode, onUpdate_jsCode, LastUpdated);' | sudo mysql

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 v0.4 - has an "export" and "import" module that converts sql data into a "git repo" / folder with code
 
-v0.3 - supports Javacript / ECMA Script, and npm package manager
 
 ## AS IS:
 
-v0.2 - has a function called "sql_read_hidrate()" that gives the foreign keys hidrated 
+v0.3 - supports Javascript / ECMA Script, and npm package manager
+v0.2 - has a function called "sql_read_hidrate()" that gives the foreign keys hidrated
         - (useful for trigger functions like telegram outbox that need data like recipients hidrated)
 
 v0.1 - works.

--- a/install/SYS_PRD_BND.Npm.sql
+++ b/install/SYS_PRD_BND.Npm.sql
@@ -1,0 +1,8 @@
+USE SYS_PRD_BND;
+CREATE TABLE `Npm` (
+  `PackageName` varchar(255) NOT NULL,
+  `AliasName` varchar(255) DEFAULT NULL,
+  `VersionOrTag` varchar(25) DEFAULT NULL,
+  `LastUpdated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`PackageName`)
+);

--- a/install/SYS_PRD_BND.Tables.sql
+++ b/install/SYS_PRD_BND.Tables.sql
@@ -3,6 +3,7 @@ CREATE TABLE `Tables` (
   `Name` varchar(255) NOT NULL,
   `onUpdate_phpCode` text DEFAULT NULL,
   `onUpdate_pyCode` text DEFAULT NULL,
+  `onUpdate_jsCode` text DEFAULT NULL,
   `LastError` text DEFAULT NULL,
   `LastUpdated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`Name`)

--- a/package.json.php
+++ b/package.json.php
@@ -1,0 +1,29 @@
+<?php
+
+$dsn = "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=SYS_PRD_BND;charset=utf8mb4";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
+
+try {
+    $pdo = new PDO($dsn, "root", "", $options);
+
+    $stmt = $pdo->query("SELECT PackageName, VersionOrTag FROM Npm ORDER BY PackageName");
+    $dependencies = [];
+    foreach ($stmt as $row) {
+        $ver = $row['VersionOrTag'];
+        $dependencies[$row['PackageName']] = $ver ?: '*';
+    }
+
+    $packageJson = [
+        'type' => 'module',
+        'dependencies' => (object)$dependencies,
+    ];
+
+    file_put_contents('php://stdout', json_encode($packageJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    file_put_contents('php://stderr', "✅ package.json generated successfully.\n");
+
+} catch (PDOException $e) {
+    file_put_contents('php://stderr', "❌ Database error: " . $e->getMessage() . "\n");
+}

--- a/plt/generateJSTriggerCode.inc.php
+++ b/plt/generateJSTriggerCode.inc.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Generates JavaScript code for sandbox execution based on provided trigger code and row data.
+ *
+ * @param string $functionName The name of the JavaScript function to generate.
+ * @param string $jsCode       The JavaScript code to embed within the generated function.
+ * @param array  $row          The row data to pass to the generated function.
+ *
+ * @return string The complete JavaScript code ready for sandbox execution.
+ */
+function generateJSTriggerCode($functionName, $jsCode, $row) {
+    $constants = getJSConstantsDefinition();
+    $supportFunctions = getJavascriptSupportFunctionsDefinition();
+    $requires = getNodeRequires();
+
+    $rowJson = json_encode($row, JSON_UNESCAPED_SLASHES);
+    $indentedCode = implode("\n", array_map(fn($l) => '    ' . $l, explode("\n", $jsCode)));
+
+    $javascript = <<<JS
+$requires
+$constants
+$supportFunctions
+function $functionName(data, error) {
+$indentedCode
+}
+let data = $rowJson;
+let error = null;
+$functionName(data, error);
+console.log(JSON.stringify(data));
+JS;
+    return $javascript;
+}

--- a/plt/runSandboxedJavascript.inc.php
+++ b/plt/runSandboxedJavascript.inc.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Runs dynamically generated JavaScript code in a sandboxed environment using Node.js.
+ *
+ * @param string $code   The JavaScript code to execute.
+ * @param string &$stdout Captured standard output from the execution.
+ * @param string &$stderr Captured standard error from the execution.
+ *
+ * @return int Exit code of the executed script (0 means success).
+ */
+function runSandboxedJavascript($code, &$stdout = null, &$stderr = null) {
+    $tempFile = tempnam(sys_get_temp_dir(), 'sandboxed_') . '.js';
+
+    file_put_contents($tempFile, $code);
+
+    $command = "/usr/bin/node " . escapeshellarg($tempFile);
+
+    $descriptorspec = [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open($command, $descriptorspec, $pipes);
+
+    if (!is_resource($process)) {
+        unlink($tempFile);
+        throw new Exception('Failed to execute sandboxed JavaScript code.');
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+
+    $exitCode = proc_close($process);
+
+    unlink($tempFile);
+
+    return $exitCode;
+}


### PR DESCRIPTION
## Summary
- create Npm table and generate `package.json`
- support JavaScript triggers
- run node code via sandbox
- update wrapper, Makefile, README and gitignore
- remove duplicate JavaScript entry in README

## Testing
- `php -l package.json.php`
- `php -l plt/runSandboxedJavascript.inc.php`
- `php -l plt/generateJSTriggerCode.inc.php`
- `php -l plt/index.php`
- `php -l composer.json.php`
- `bash -n DbContinuousIntegrationWrapper.sh`


------
https://chatgpt.com/codex/tasks/task_e_684a94d902ec83219df655d40227715b